### PR TITLE
feat: support committer auther define

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ up to you.
 co-author hook
 ```
 
+## Load Config
+Make it refer to the config.When there is a config, only refer to the config.
+This makes it possible to target only those who participate in mob programming.
+
+this file name only `.git-co-authors.yaml`
+```yaml
+committers:
+  - name: user
+    email: user@example.com
+...
+```
+
 ## Contributing
 
 Feel free to add anything useful or fix something.

--- a/commit_cmd.go
+++ b/commit_cmd.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
-	"log"
-	"os"
 )
 
 var (
@@ -85,7 +86,6 @@ func newModel() *model {
 			listKeys.toggleHelpMenu,
 		}
 	}
-
 	return &model{
 		list:         committerList,
 		keys:         listKeys,

--- a/committer.go
+++ b/committer.go
@@ -2,28 +2,29 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/charmbracelet/bubbles/list"
 )
 
 type committer struct {
-	name     string
-	email    string
+	Name     string `yaml:"name,omitempty"`
+	Email    string `yaml:"email,omitempty"`
 	selected bool
 }
 
 func (c *committer) Title() string {
 	if c.selected {
-		return fmt.Sprintf("[X] %s", c.name)
+		return fmt.Sprintf("[X] %s", c.Name)
 	}
-	return fmt.Sprintf("[ ] %s", c.name)
+	return fmt.Sprintf("[ ] %s", c.Name)
 }
 
 func (c *committer) Description() string {
-	return c.email
+	return c.Email
 }
 
 func (c *committer) FilterValue() string {
-	return c.name
+	return c.Name
 }
 
 func (c *committer) ToggleSelect() {

--- a/delegate.go
+++ b/delegate.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"log"
 )
 
 const (
@@ -30,9 +31,9 @@ func newItemDelegate(keys *delegateKeyMap) list.DefaultDelegate {
 
 				var message string
 				if item.selected {
-					message = fmt.Sprintf(itemSelectMessageFormat, item.name)
+					message = fmt.Sprintf(itemSelectMessageFormat, item.Name)
 				} else {
-					message = fmt.Sprintf(itemUnSelectMessageFormat, item.name)
+					message = fmt.Sprintf(itemUnSelectMessageFormat, item.Name)
 				}
 
 				return m.NewStatusMessage(statusMessageStyle(message))

--- a/file.go
+++ b/file.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+var CONFIG_FILES = ".git-co-authors.yaml"
+
+type config struct {
+	Committers []committer `yaml:"committers,omitempty"`
+}
+
+func fileOpen(filename string) ([]byte, error) {
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return buf, nil
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+func configload(filename string) (*config, error) {
+	buf, err := fileOpen(filename)
+	if err != nil {
+		return nil, err
+	}
+	cfg := &config{}
+	err = yaml.Unmarshal(buf, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -53,5 +53,7 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed h1:Ei4bQjjpYUsS4efOUz+5Nz++IVkHk87n2zBA0NxBWc0=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Hello. maintainer.
Thanks for the coolest tool! I tried to add functions to make it easier for me to use, so please take care of it :)

## Summary
This PR supports the ability to select participants added to `.git-co-authors.yaml`.
This gives you flexibility in choosing a commiter.
This can be useful for things like mob programming.

## HowTo

this yaml write for `git-co-authors.yaml`
`git-co-authors.yaml` on the repo root
```yaml
committers:
  - name: user
    email: user@example.com
  - name: user2
    email: user2@example.com
  - name: user3
    email: user3@example.com
```

this result
<img width="1158" alt="スクリーンショット 2023-01-24 16 05 11" src="https://user-images.githubusercontent.com/10973623/214231307-7cc8ade9-cc05-4b73-b872-267d2e73409c.png">
